### PR TITLE
Support auto-item

### DIFF
--- a/contao/dca/tl_recommendation.php
+++ b/contao/dca/tl_recommendation.php
@@ -217,6 +217,11 @@ $GLOBALS['TL_DCA']['tl_recommendation'] = [
             'eval'                    => ['doNotCopy'=>true, 'maxlength'=>255, 'tl_class'=>'w100 clr'],
             'sql'                     => "varchar(255) NOT NULL default ''"
         ],
+        'scope' => [
+            'inputType'               => 'text',
+            'filter'                  => true,
+            'sql'                     => "varchar(255) NOT NULL default ''"
+        ],
         'cssClass' => [
             'exclude'                 => true,
             'inputType'               => 'text',

--- a/contao/dca/tl_recommendation_archive.php
+++ b/contao/dca/tl_recommendation_archive.php
@@ -89,7 +89,7 @@ $GLOBALS['TL_DCA']['tl_recommendation_archive'] = [
     // Palettes
     'palettes' => [
         '__selector__'                => ['protected'],
-        'default'                     => '{title_legend},title,jumpTo,useAutoItem;{protected_legend:hide},protected'
+        'default'                     => '{title_legend},title,jumpTo;{expert_legend:hide},useAutoItem;{protected_legend:hide},protected'
     ],
 
     // Subpalettes

--- a/contao/dca/tl_recommendation_archive.php
+++ b/contao/dca/tl_recommendation_archive.php
@@ -89,7 +89,7 @@ $GLOBALS['TL_DCA']['tl_recommendation_archive'] = [
     // Palettes
     'palettes' => [
         '__selector__'                => ['protected'],
-        'default'                     => '{title_legend},title,jumpTo;{protected_legend:hide},protected'
+        'default'                     => '{title_legend},title,jumpTo,useAutoItem;{protected_legend:hide},protected'
     ],
 
     // Subpalettes
@@ -125,6 +125,12 @@ $GLOBALS['TL_DCA']['tl_recommendation_archive'] = [
             'filter'                  => true,
             'inputType'               => 'checkbox',
             'eval'                    => ['submitOnChange'=>true],
+            'sql'                     => "char(1) NOT NULL default ''"
+        ],
+        'useAutoItem' => [
+            'exclude'                 => true,
+            'filter'                  => true,
+            'inputType'               => 'checkbox',
             'sql'                     => "char(1) NOT NULL default ''"
         ],
         'groups' => [

--- a/contao/dca/tl_recommendation_archive.php
+++ b/contao/dca/tl_recommendation_archive.php
@@ -89,7 +89,7 @@ $GLOBALS['TL_DCA']['tl_recommendation_archive'] = [
     // Palettes
     'palettes' => [
         '__selector__'                => ['protected'],
-        'default'                     => '{title_legend},title,jumpTo;{expert_legend:hide},useAutoItem;{protected_legend:hide},protected'
+        'default'                     => '{title_legend},title,jumpTo;{protected_legend:hide},protected;{expert_legend:hide},useAutoItem'
     ],
 
     // Subpalettes

--- a/contao/languages/de/tl_recommendation_archive.xlf
+++ b/contao/languages/de/tl_recommendation_archive.xlf
@@ -49,6 +49,10 @@
         <source>Access protection</source>
         <target>Zugriffsschutz</target>
       </trans-unit>
+      <trans-unit id="tl_recommendation_archive.expert_legend">
+        <source>Expert settings</source>
+        <target>Experteneinstellungen</target>
+      </trans-unit>
       <trans-unit id="tl_recommendation_archive.settings.0">
         <source>Settings</source>
         <target>Einstellungen</target>

--- a/contao/languages/de/tl_recommendation_list.xlf
+++ b/contao/languages/de/tl_recommendation_list.xlf
@@ -53,6 +53,10 @@
         <source>Rating descending</source>
         <target>Bewertung absteigend</target>
       </trans-unit>
+      <trans-unit id="tl_recommendation_list.recommendation_count">
+        <source>%s Reviews</source>
+        <target>%s Bewertungen</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/contao/languages/en/tl_recommendation_archive.xlf
+++ b/contao/languages/en/tl_recommendation_archive.xlf
@@ -34,6 +34,9 @@
       <trans-unit id="tl_recommendation_archive.title_legend">
         <source>Title and redirect page</source>
       </trans-unit>
+      <trans-unit id="tl_recommendation_archive.expert_legend">
+        <source>Expert settings</source>
+      </trans-unit>
       <trans-unit id="tl_recommendation_archive.protected_legend">
         <source>Access protection</source>
       </trans-unit>

--- a/contao/languages/en/tl_recommendation_list.xlf
+++ b/contao/languages/en/tl_recommendation_list.xlf
@@ -40,6 +40,9 @@
       <trans-unit id="tl_recommendation_list.order_rating_desc">
         <source>Rating descending</source>
       </trans-unit>
+      <trans-unit id="tl_recommendation_list.recommendation_count">
+        <source>%s Reviews</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/contao/modules/ModuleRecommendation.php
+++ b/contao/modules/ModuleRecommendation.php
@@ -185,15 +185,12 @@ abstract class ModuleRecommendation extends Module
         $count = 0;
         $arrRecommendations = [];
 
-        while ($objRecommendations->next())
+        foreach ($objRecommendations as $recommendation)
         {
-            /** @var RecommendationModel $objRecommendation */
-            $objRecommendation = $objRecommendations->current();
-
             /** @var RecommendationArchiveModel $objRecommendationArchive */
-            $objRecommendationArchive = $objRecommendation->getRelated('pid');
+            $objRecommendationArchive = $recommendation->getRelated('pid');
 
-            $arrRecommendations[] = $this->parseRecommendation($objRecommendation, $objRecommendationArchive, ((++$count == 1) ? ' first' : '') . (($count == $limit) ? ' last' : '') . ((($count % 2) == 0) ? ' odd' : ' even'), $count);
+            $arrRecommendations[] = $this->parseRecommendation($recommendation, $objRecommendationArchive, ((++$count == 1) ? ' first' : '') . (($count == $limit) ? ' last' : '') . ((($count % 2) == 0) ? ' odd' : ' even'), $count);
         }
 
         return $arrRecommendations;

--- a/contao/modules/ModuleRecommendationForm.php
+++ b/contao/modules/ModuleRecommendationForm.php
@@ -95,6 +95,10 @@ class ModuleRecommendationForm extends ModuleRecommendation
             return;
         }
 
+        // Get archive record
+        $archive = RecommendationArchiveModel::findMultipleByIds($this->recommendation_archives);
+        $archive = $archive[0] ?? null;
+
         // Form fields
         $arrFields = [
             'author' => [
@@ -141,6 +145,16 @@ class ModuleRecommendationForm extends ModuleRecommendation
                 'eval'      => ['optional'=>true, 'maxlength'=>255, 'rgxp'=>'email', 'decodeEntities'=>true],
             ],
         ];
+
+        // Add scope for auto alias archives
+        if($archive && $archive->useAutoItem)
+        {
+            $arrFields['scope'] = [
+                'name'      => 'scope',
+                'inputType' => 'hidden',
+                'value'     => Input::get('auto_item')
+            ];
+        }
 
         // Captcha
         if (!$this->recommendation_disableCaptcha)
@@ -266,6 +280,7 @@ class ModuleRecommendationForm extends ModuleRecommendation
                 'time' => $time,
                 'text' => $this->convertLineFeeds($strText),
                 'rating' => $arrWidgets['rating']->value,
+                'scope' => $arrWidgets['scope']->value ?? '',
                 'published' => $this->recommendation_moderate ? '' : 1
             ];
 

--- a/contao/modules/ModuleRecommendationList.php
+++ b/contao/modules/ModuleRecommendationList.php
@@ -10,6 +10,7 @@ namespace Oveleon\ContaoRecommendationBundle;
 
 use Contao\BackendTemplate;
 use Contao\Config;
+use Contao\Controller;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\Environment;
 use Contao\Input;
@@ -17,6 +18,7 @@ use Contao\Model\Collection;
 use Contao\Pagination;
 use Contao\StringUtil;
 use Contao\System;
+use Oveleon\ContaoRecommendationBundle\Model\RecommendationArchiveModel;
 use Oveleon\ContaoRecommendationBundle\Model\RecommendationModel;
 
 /**
@@ -162,11 +164,32 @@ class ModuleRecommendationList extends ModuleRecommendation
 
         $objRecommendations = $this->fetchItems($this->recommendation_archives, $blnFeatured, ($limit ?: 0), $offset, $minRating);
 
+        // Add summary details
+        $this->Template->totalCount = $intTotal;
+        $this->addSummary($objRecommendations);
+
         // Add recommendations
         if ($objRecommendations !== null)
         {
             $this->Template->recommendations = $this->parseRecommendations($objRecommendations);
         }
+    }
+
+    protected function addSummary($objRecommendations): void
+    {
+        Controller::loadLanguageFile('tl_recommendation_list');
+
+        $ratings = $objRecommendations->fetchEach('rating');
+        $grouped = \array_count_values($ratings);
+        $average = 0;
+
+        \array_walk($grouped, static function ($count, $number) use (&$average){
+            $average += ($number * $count);
+        });
+
+        $this->Template->average = $average / $this->Template->totalCount;
+        $this->Template->averageRound = ceil($this->Template->average);
+        $this->Template->countLabel = sprintf($GLOBALS['TL_LANG']['tl_recommendation_list']['recommendation_count'], $this->Template->totalCount);
     }
 
     /**
@@ -196,7 +219,8 @@ class ModuleRecommendationList extends ModuleRecommendation
             }
         }
 
-        return RecommendationModel::countPublishedByPids($recommendationArchives, $blnFeatured, $minRating);
+        //return RecommendationModel::countPublishedByPids($recommendationArchives, $blnFeatured, $minRating);
+        return $this->fetchItems($recommendationArchives, $blnFeatured, 0, 0, $minRating)?->count() ?? 0;
     }
 
     /**
@@ -247,7 +271,34 @@ class ModuleRecommendationList extends ModuleRecommendation
                 $order .= "$t.date DESC";
         }
 
-        return RecommendationModel::findPublishedByPids($recommendationArchives, $blnFeatured, $limit, $offset, $minRating, ['order'=>$order]);
+        // Get archives
+        $archives = RecommendationArchiveModel::findMultipleByIds($recommendationArchives);
+        $archives = array_combine(
+            $archives->fetchEach('id'),
+            $archives->fetchAll()
+        );
+
+        // Fetch items
+        $items = [];
+
+        // Get auto item
+        $autoItem = Input::get('auto_item');
+
+        foreach (RecommendationModel::findPublishedByPids($recommendationArchives, $blnFeatured, $limit, $offset, $minRating, ['order'=>$order]) ?? [] as $item)
+        {
+            if($archives[$item->pid]['useAutoItem'] ?? null)
+            {
+                // Add only if the scope match to the current auto_item
+                if($autoItem === $item->scope)
+                {
+                    $items[] = $item;
+                }
+            }else{
+                $items[] = $item;
+            }
+        }
+
+        return new Collection($items, $t);
     }
 }
 

--- a/src/Model/RecommendationArchiveModel.php
+++ b/src/Model/RecommendationArchiveModel.php
@@ -19,6 +19,7 @@ use Contao\Model\Collection;
  * @property string  $title
  * @property integer $jumpTo
  * @property boolean $protected
+ * @property boolean $useAutoItem
  * @property string  $groups
  *
  * @method static RecommendationArchiveModel|null findById($id, array $opt=array())


### PR DESCRIPTION
This PR supports Contao's auto-item function. Thus, this extension can be used for news items or other auto-item based pages. Also for isotopes or EstateManager detail pages, ratings can be submitted.

A new checkbox is added to an archive, which declares the archive as a "dynamic archive". Ratings within a dynamic archive receive a 'scope' in which the auto-item value is entered (usually only makes sense if the rating form is integrated in these pages).

The list and the form react to this setting. Furthermore, a new summary template has been added, which allows the display of a list as follows:

![image](https://github.com/oveleon/contao-recommendation-bundle/assets/48379929/db9c282a-9ee8-4d39-b11d-9e1eafe2bd3c)
