### PR TITLE
Do not mark `auto_item` as used in non-reader modules

### DIFF
--- a/contao/modules/ModuleRecommendationForm.php
+++ b/contao/modules/ModuleRecommendationForm.php
@@ -152,7 +152,7 @@ class ModuleRecommendationForm extends ModuleRecommendation
             $arrFields['scope'] = [
                 'name'      => 'scope',
                 'inputType' => 'hidden',
-                'value'     => Input::get('auto_item')
+                'value'     => Input::get('auto_item', false, true)
             ];
         }
 

--- a/contao/modules/ModuleRecommendationList.php
+++ b/contao/modules/ModuleRecommendationList.php
@@ -282,7 +282,7 @@ class ModuleRecommendationList extends ModuleRecommendation
         $items = [];
 
         // Get auto item
-        $autoItem = Input::get('auto_item');
+        $autoItem = Input::get('auto_item', false, true);
 
         foreach (RecommendationModel::findPublishedByPids($recommendationArchives, $blnFeatured, $limit, $offset, $minRating, ['order'=>$order]) ?? [] as $item)
         {


### PR DESCRIPTION
The `ModuleRecommendationList` and `ModuleRecommendationForm` modules currently use `Input::get('auto_item')` without setting the 3rd argument (`$blnKeepUnused`) to true. This causes all "auto item" URLs in Contao to be valid wherever these modules are integrated, i.e. they will not show a 404 even though they are supposed to, when no valid reader is on that page.