### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,12 @@ If you are familiar using the news- or events bundle, you should be able to set 
 
    ![Admin View: Recommendation Archive Settings](https://www.oveleon.de/share/github-assets/contao-recommendation-bundle/recommendationArchiveSettings.jpg)
 
+5. Setting up the recommendation alias
+    - Within the recommendation settings, you can update the default-prefix for aliases when no title has been given
 
-5. Setting up a recommendation-reader for a redirect page
+   ![Admin View: Recommendation Reader](https://www.oveleon.de/share/github-assets/contao-recommendation-bundle/defaultAlias.jpg)
+
+6. Setting up a recommendation-reader for a redirect page
    1. Create the front end module *recommendation-reader*
    2. Choose your recommendation archive/s
    3. Choose the meta fields you want to show in your front end

--- a/contao/dca/tl_recommendation_settings.php
+++ b/contao/dca/tl_recommendation_settings.php
@@ -20,7 +20,7 @@ $GLOBALS['TL_DCA']['tl_recommendation_settings'] = [
 
     // Palettes
     'palettes' => [
-        'default'                     => '{recommendation_legend},recommendationDefaultImage,recommendationActiveColor;'
+        'default'                     => '{recommendation_legend},recommendationDefaultImage,recommendationActiveColor,recommendationAliasPrefix;'
     ],
 
     // Fields
@@ -42,6 +42,21 @@ $GLOBALS['TL_DCA']['tl_recommendation_settings'] = [
                     }
 
                     return serialize(array_map('\Contao\StringUtil::restoreBasicEntities', $value));
+                }
+            ]
+        ],
+        'recommendationAliasPrefix' => [
+            'inputType'               => 'text',
+            'eval'                    => ['rgxp'=>'alias', 'maxlength'=>255, 'tl_class'=>'w50 clr'],
+            'save_callback'           => [
+                static function ($value)
+                {
+                    if (!$value)
+                    {
+                        $value = &$GLOBALS['TL_LANG']['tl_recommendation_settings']['defaultPrefix'];
+                    }
+
+                    return $value;
                 }
             ]
         ]

--- a/contao/languages/de/tl_recommendation.xlf
+++ b/contao/languages/de/tl_recommendation.xlf
@@ -317,6 +317,10 @@
         <source>just now</source>
         <target>gerade eben</target>
       </trans-unit>
+      <trans-unit id="tl_recommendation.aliasPrefix">
+        <source>recommendation</source>
+        <target>bewertung</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/contao/languages/de/tl_recommendation_settings.xlf
+++ b/contao/languages/de/tl_recommendation_settings.xlf
@@ -1,6 +1,10 @@
 <?xml version="1.0" ?><xliff version="1.1">
   <file datatype="php" original="contao/languages/en/tl_recommendation_settings.php" source-language="en" target-language="de">
     <body>
+      <trans-unit id="tl_recommendation_settings.recommendation_legend">
+        <source>Settings</source>
+        <target>Einstellungen</target>
+      </trans-unit>
       <trans-unit id="tl_recommendation_settings.recommendationDefaultImage.0">
         <source>Default image</source>
         <target>Standard-Bild</target>
@@ -17,9 +21,17 @@
         <source>Color value will be set as inline css style in the html code.</source>
         <target>Farbwert wird als inline css style im HTML code gesetzt.</target>
       </trans-unit>
-      <trans-unit id="tl_recommendation_settings.recommendation_legend">
-        <source>Settings</source>
-        <target>Einstellungen</target>
+      <trans-unit id="tl_recommendation_settings.recommendationAliasPrefix.0">
+        <source>Alias prefix</source>
+        <target>Alias-Präfix</target>
+      </trans-unit>
+      <trans-unit id="tl_recommendation_settings.recommendationAliasPrefix.1">
+        <source>Here you can enter an alias prefix that will precede a recommendation alias if no title has been entered.</source>
+        <target>Hier können Sie einen Alias-Präfix eingeben, der einem Bewertungsalias vorangestellt wird, wenn kein Titel eingegeben wurde.</target>
+      </trans-unit>
+      <trans-unit id="tl_recommendation_settings.defaultPrefix">
+        <source>recommendation</source>
+        <target>bewertung</target>
       </trans-unit>
     </body>
   </file>

--- a/contao/languages/en/tl_recommendation.xlf
+++ b/contao/languages/en/tl_recommendation.xlf
@@ -238,6 +238,9 @@
       <trans-unit id="tl_recommendation.justNow">
         <source>just now</source>
       </trans-unit>
+      <trans-unit id="tl_recommendation.aliasPrefix">
+        <source>recommendation</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/contao/languages/en/tl_recommendation_settings.xlf
+++ b/contao/languages/en/tl_recommendation_settings.xlf
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?><xliff version="1.1">
   <file datatype="php" original="contao/languages/en/tl_recommendation_settings.php" source-language="en">
     <body>
+      <trans-unit id="tl_recommendation_settings.recommendation_legend">
+        <source>Settings</source>
+      </trans-unit>
       <trans-unit id="tl_recommendation_settings.recommendationDefaultImage.0">
         <source>Default image</source>
       </trans-unit>
@@ -13,8 +16,14 @@
       <trans-unit id="tl_recommendation_settings.recommendationActiveColor.1">
         <source>Color value will be set as inline css style in the html code.</source>
       </trans-unit>
-      <trans-unit id="tl_recommendation_settings.recommendation_legend">
-        <source>Settings</source>
+      <trans-unit id="tl_recommendation_settings.recommendationAliasPrefix.0">
+        <source>Alias prefix</source>
+      </trans-unit>
+      <trans-unit id="tl_recommendation_settings.recommendationAliasPrefix.1">
+        <source>Here you can enter an alias prefix that will precede a recommendation alias if no title has been entered.</source>
+      </trans-unit>
+      <trans-unit id="tl_recommendation_settings.defaultPrefix">
+        <source>recommendation</source>
       </trans-unit>
     </body>
   </file>

--- a/src/EventListener/DataContainer/RecommendationListener.php
+++ b/src/EventListener/DataContainer/RecommendationListener.php
@@ -82,7 +82,13 @@ class RecommendationListener
         // Generate alias if there is none
         if (!$varValue)
         {
-            $varValue = System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, RecommendationArchiveModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
+            // Use alias prefix if no title has been set
+            if (!$title = $dc->activeRecord->title)
+            {
+                $title = Config::get('recommendationAliasPrefix') ?? 'recommendation';
+            }
+
+            $varValue = System::getContainer()->get('contao.slug')->generate($title, RecommendationArchiveModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
         }
         elseif (preg_match('/^[1-9]\d*$/', $varValue))
         {

--- a/src/Model/RecommendationModel.php
+++ b/src/Model/RecommendationModel.php
@@ -124,7 +124,7 @@ class RecommendationModel extends Model
         }
 
         $t = static::$strTable;
-        $arrColumns = !is_numeric($varId) ? ["$t.alias=?"] : ["$t.id=?"];
+        $arrColumns = !preg_match('/^[1-9]\d*$/', $varId) ? ["BINARY $t.alias=?"] : ["$t.id=?"];
         $arrColumns[] = "$t.pid IN(" . implode(',', array_map('\intval', $arrPids)) . ") AND $t.verified='1'";
 
         if (!static::isPreviewMode($arrOptions))


### PR DESCRIPTION
<h3>Bugfixes</h3>

- Fixed an issue with recommendations not being found when aliases were numeric 5eefcc288db0b54f323b3483caab54b0ed9501f
- Generate aliases with a prefix beef713c2bc3d721c5594aa15853c8b0987f4286
  > You can change the prefix in the recommendation settings (See [initial setup](https://github.com/oveleon/contao-recommendation-bundle#initial-setup))