### PR TITLE
Prevent missing images with urlencoded characters

### DIFF
--- a/contao/modules/ModuleRecommendation.php
+++ b/contao/modules/ModuleRecommendation.php
@@ -138,7 +138,7 @@ abstract class ModuleRecommendation extends Module
         // Add an image
         if ($objRecommendation->imageUrl != '')
         {
-            $objRecommendation->imageUrl = $container->get('contao.insert_tag.parser')->replace($objRecommendation->imageUrl);
+            $objRecommendation->imageUrl = urldecode($container->get('contao.insert_tag.parser')->replace($objRecommendation->imageUrl));
 
             // Insert tag parser on contao ^5 returns a leading slash whilst contao 4.13 does not
             if (Path::isAbsolute($objRecommendation->imageUrl))


### PR DESCRIPTION
If the image contains an url encoded image the image is not found. The insert tag replacer returns an urlencoded image url. Encoded characters like spaces would lead to an missing image.